### PR TITLE
Remove deprecated tabu package

### DIFF
--- a/template.tex
+++ b/template.tex
@@ -27,7 +27,6 @@
 \renewcommand*\ttdefault{txtt}         % a nicer typewriter font
 
 %% Only used in the template examples. You can remove these lines.
-\usepackage{tabu}                      % only used for the table example
 \usepackage{booktabs}                  % only used for the table example
 \usepackage{lipsum}                    % used to generate placeholder text
 \usepackage{mwe}                       % used to generate placeholder figures
@@ -240,7 +239,7 @@ rebum.
   \label{tab:vis_papers}
   \scriptsize%
 	\centering%
-  \begin{tabu}{%
+  \begin{tabular}{%
 	r%
 	*{7}{c}%
 	*{2}{r}%
@@ -278,7 +277,7 @@ rebum.
   \midrule
   \textbf{sum} & \textbf{1545} & \textbf{9} & \textbf{632} & \textbf{310} & \textbf{50} & \textbf{123} & \textbf{25} & \textbf{2694} & \textbf{2546} \\
   \bottomrule
-  \end{tabu}%
+  \end{tabular}%
 \end{table}
 
 \subsection{Filler Subsection to Flush Out the Paper}


### PR DESCRIPTION
This PR removes the _tabu_ package, which is deprecated, and does not compile with the newer LaTeX distributions. The tabu environment is replaced by tabular, which is a standard today.